### PR TITLE
ConfigureAwait(false) to avoid deadlocks

### DIFF
--- a/src/Csg.ListQuery.AspNetCore/ControllerExtensions.cs
+++ b/src/Csg.ListQuery.AspNetCore/ControllerExtensions.cs
@@ -44,7 +44,7 @@ namespace Csg.ListQuery.AspNetCore.Mvc
                 return controller.ValidationProblem(controller.ModelState);
             }
 
-            var queryResult = await executeQueryMethod(validationResult.ListQuery);
+            var queryResult = await executeQueryMethod(validationResult.ListQuery).ConfigureAwait(false);
 
             return queryResult.ToListResponse<TInfrastructure, TDomain>(
                 request,

--- a/src/Csg.ListQuery.Client.Abstractions/ListResponseExtensions.cs
+++ b/src/Csg.ListQuery.Client.Abstractions/ListResponseExtensions.cs
@@ -30,8 +30,8 @@ namespace Csg.ListQuery.Client
 
             while (nextUrl != null && pageCount < (maxRequests ?? Int32.MaxValue))
             {
-                await Task.Delay(delayBetweenRequests);
-                var responseObject = await client.GetAsync<TData>(nextUrl);
+                await Task.Delay(delayBetweenRequests).ConfigureAwait(false);
+                var responseObject = await client.GetAsync<TData>(nextUrl).ConfigureAwait(false);
                 result = result.Concat(responseObject.Data);
                 nextUrl = responseObject.Links?.Next;
                 pageCount++;
@@ -63,9 +63,9 @@ namespace Csg.ListQuery.Client
 
             while (nextOffset != null && pageCount < (maxPagesToFetch ?? Int32.MaxValue))
             {
-                await Task.Delay(delayBetweenRequests);
+                await Task.Delay(delayBetweenRequests).ConfigureAwait(false);
                 request.Offset = nextOffset.Value;
-                var responseObject = await client.PostAsync<TData>(url, request);
+                var responseObject = await client.PostAsync<TData>(url, request).ConfigureAwait(false);
                 result = result.Concat(responseObject.Data);
                 nextOffset = responseObject.Meta?.Next?.Offset;
                 pageCount++;

--- a/src/Csg.ListQuery.Sql/DapperListDataAdapter.cs
+++ b/src/Csg.ListQuery.Sql/DapperListDataAdapter.cs
@@ -24,7 +24,7 @@ namespace Csg.ListQuery.Sql
             var cmdFlags = stream ? Dapper.CommandFlags.Pipelined : Dapper.CommandFlags.Buffered;
             var cmd = batch.ToDapperCommand(_transaction, commandTimeout, commandFlags: cmdFlags);
 
-            return await Dapper.SqlMapper.QueryAsync<T>(_connection, cmd);
+            return await Dapper.SqlMapper.QueryAsync<T>(_connection, cmd).ConfigureAwait(false);
         }
 
         public async Task<BatchResult<T>> GetTotalCountAndResultsAsync<T>(SqlStatementBatch batch, bool stream, int commandTimeout)
@@ -34,10 +34,10 @@ namespace Csg.ListQuery.Sql
 
             var result = new BatchResult<T>();
 
-            using (var batchReader = await Dapper.SqlMapper.QueryMultipleAsync(_connection, cmd))
+            using (var batchReader = await Dapper.SqlMapper.QueryMultipleAsync(_connection, cmd).ConfigureAwait(false))
             {
-                result.TotalCount = await batchReader.ReadFirstAsync<int>();
-                result.Items = await batchReader.ReadAsync<T>();
+                result.TotalCount = await batchReader.ReadFirstAsync<int>().ConfigureAwait(false);
+                result.Items = await batchReader.ReadAsync<T>().ConfigureAwait(false);
             }
 
             return result;

--- a/src/Csg.ListQuery.Sql/ListQueryExtensions.cs
+++ b/src/Csg.ListQuery.Sql/ListQueryExtensions.cs
@@ -314,12 +314,12 @@ namespace Csg.ListQuery.Sql
             if (stmt.Count == 1)
             {
                 data = await builder.Configuration.DataAdapter.GetResultsAsync<T>(stmt, builder.Configuration.UseStreamingResult, builder.Configuration.QueryBuilder.CommandTimeout).ConfigureAwait(false);
-                var batchResult = await builder.Configuration.DataAdapter.GetTotalCountAndResultsAsync<T>(appiedQuery, builder.Configuration.UseStreamingResult, builder.Configuration.QueryBuilder.Configuration.CommandTimeout).ConfigureAwait(false);
-
             }
             else if (stmt.Count == 2)
             {
                 var batchResult = await builder.Configuration.DataAdapter.GetTotalCountAndResultsAsync<T>(stmt, builder.Configuration.UseStreamingResult, builder.Configuration.QueryBuilder.CommandTimeout).ConfigureAwait(false);
+                data = batchResult.Items;
+                totalCount = batchResult.TotalCount;
             }
             else
             {

--- a/src/Csg.ListQuery.Sql/ListQueryExtensions.cs
+++ b/src/Csg.ListQuery.Sql/ListQueryExtensions.cs
@@ -313,12 +313,12 @@ namespace Csg.ListQuery.Sql
 
             if (stmt.Count == 1)
             {
-                data = await builder.Configuration.DataAdapter.GetResultsAsync<T>(stmt, builder.Configuration.UseStreamingResult, builder.Configuration.QueryBuilder.CommandTimeout);
+                data = await builder.Configuration.DataAdapter.GetResultsAsync<T>(stmt, builder.Configuration.UseStreamingResult, builder.Configuration.QueryBuilder.CommandTimeout).ConfigureAwait(false);
 
             }
             else if (stmt.Count == 2)
             {
-                var batchResult = await builder.Configuration.DataAdapter.GetTotalCountAndResultsAsync<T>(stmt, builder.Configuration.UseStreamingResult, builder.Configuration.QueryBuilder.CommandTimeout);
+                var batchResult = await builder.Configuration.DataAdapter.GetTotalCountAndResultsAsync<T>(stmt, builder.Configuration.UseStreamingResult, builder.Configuration.QueryBuilder.CommandTimeout).ConfigureAwait(false);
             }
             else
             {

--- a/src/Csg.ListQuery.Sql/ListQueryExtensions.cs
+++ b/src/Csg.ListQuery.Sql/ListQueryExtensions.cs
@@ -314,6 +314,7 @@ namespace Csg.ListQuery.Sql
             if (stmt.Count == 1)
             {
                 data = await builder.Configuration.DataAdapter.GetResultsAsync<T>(stmt, builder.Configuration.UseStreamingResult, builder.Configuration.QueryBuilder.CommandTimeout).ConfigureAwait(false);
+                var batchResult = await builder.Configuration.DataAdapter.GetTotalCountAndResultsAsync<T>(appiedQuery, builder.Configuration.UseStreamingResult, builder.Configuration.QueryBuilder.Configuration.CommandTimeout).ConfigureAwait(false);
 
             }
             else if (stmt.Count == 2)

--- a/tests/Csg.ListQuery.AspNetCore.Tests/Csg.ListQuery.AspNetCore.Tests.csproj
+++ b/tests/Csg.ListQuery.AspNetCore.Tests/Csg.ListQuery.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Csg.ListQuery.Tests/Csg.ListQuery.Tests.csproj
+++ b/tests/Csg.ListQuery.Tests/Csg.ListQuery.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Use ConfigureAwait(false) everywhere that await is used to avoid deadlocks in callers.